### PR TITLE
bug fixes in sincnet.py and model.py

### DIFF
--- a/model.py
+++ b/model.py
@@ -9,59 +9,59 @@ from tensorflow.keras.models import Model
 from conf import *
 
 
+# added uniques names to every layer to avoid error while saving model
 def get_model(input_shape, out_dim):
-    #
     inputs = Input(input_shape)
     x = sincnet.SincConv1D(cnn_N_filt[0], cnn_len_filt[0], fs)(inputs)
 
-    x = MaxPooling1D(pool_size=cnn_max_pool_len[0])(x)
+    x = MaxPooling1D(pool_size=cnn_max_pool_len[0], name='mx1')(x)
     if cnn_use_batchnorm[0]:
-        x = BatchNormalization(momentum=0.05)(x)
+        x = BatchNormalization(momentum=0.05, name='bn1')(x)
     if cnn_use_laynorm[0]:
         x = sincnet.LayerNorm()(x)
-    x = LeakyReLU(alpha=0.2)(x)
+    x = LeakyReLU(alpha=0.2, name='lr1')(x)
 
-    x = Conv1D(cnn_N_filt[1], cnn_len_filt[1], strides=1, padding='valid')(x)
-    x = MaxPooling1D(pool_size=cnn_max_pool_len[1])(x)
+    x = Conv1D(cnn_N_filt[1], cnn_len_filt[1], strides=1, padding='valid', name='conv1')(x)
+    x = MaxPooling1D(pool_size=cnn_max_pool_len[1], name='mx2')(x)
     if cnn_use_batchnorm[1]:
-        x = BatchNormalization(momentum=0.05)(x)
+        x = BatchNormalization(momentum=0.05, name='bn2')(x)
     if cnn_use_laynorm[1]:
         x = sincnet.LayerNorm()(x)
-    x = LeakyReLU(alpha=0.2)(x)
+    x = LeakyReLU(alpha=0.2, name='lr2')(x)
 
-    x = Conv1D(cnn_N_filt[2], cnn_len_filt[2], strides=1, padding='valid')(x)
-    x = MaxPooling1D(pool_size=cnn_max_pool_len[2])(x)
+    x = Conv1D(cnn_N_filt[2], cnn_len_filt[2], strides=1, padding='valid', name='conv2')(x)
+    x = MaxPooling1D(pool_size=cnn_max_pool_len[2], name='mx3')(x)
     if cnn_use_batchnorm[2]:
-        x = BatchNormalization(momentum=0.05)(x)
+        x = BatchNormalization(momentum=0.05, name='bn3')(x)
     if cnn_use_laynorm[2]:
         x = sincnet.LayerNorm()(x)
-    x = LeakyReLU(alpha=0.2)(x)
+    x = LeakyReLU(alpha=0.2, name='lr3')(x)
     x = Flatten()(x)
 
     # DNN
-    x = Dense(fc_lay[0])(x)
+    x = Dense(fc_lay[0], name='fc1')(x)
     if fc_use_batchnorm[0]:
-        x = BatchNormalization(momentum=0.05, epsilon=1e-5)(x)
+        x = BatchNormalization(momentum=0.05, epsilon=1e-5, name='bn4')(x)
     if fc_use_laynorm[0]:
         x = sincnet.LayerNorm()(x)
-    x = LeakyReLU(alpha=0.2)(x)
+    x = LeakyReLU(alpha=0.2, name='lr4')(x)
 
-    x = Dense(fc_lay[1])(x)
+    x = Dense(fc_lay[1], name='fc2')(x)
     if fc_use_batchnorm[1]:
-        x = BatchNormalization(momentum=0.05, epsilon=1e-5)(x)
+        x = BatchNormalization(momentum=0.05, epsilon=1e-5, name='bn5')(x)
     if fc_use_laynorm[1]:
         x = sincnet.LayerNorm()(x)
-    x = LeakyReLU(alpha=0.2)(x)
+    x = LeakyReLU(alpha=0.2, name='lr5')(x)
 
-    x = Dense(fc_lay[2])(x)
+    x = Dense(fc_lay[2], name='fc3')(x)
     if fc_use_batchnorm[2]:
-        x = BatchNormalization(momentum=0.05, epsilon=1e-5)(x)
+        x = BatchNormalization(momentum=0.05, epsilon=1e-5, name='bn6')(x)
     if fc_use_laynorm[2]:
         x = sincnet.LayerNorm()(x)
-    x = LeakyReLU(alpha=0.2)(x)
+    x = LeakyReLU(alpha=0.2, name='lr6')(x)
 
     # DNN final
-    prediction = layers.Dense(out_dim, activation='softmax')(x)
-    model = Model(inputs=inputs, outputs=prediction)
+    prediction = layers.Dense(out_dim, activation='softmax', name='fc4')(x)
+    model = Model(inputs=inputs, outputs=prediction, name='SincNet_model')
     model.summary()
     return model


### PR DESCRIPTION
#### Reference Issues/PRs
#13 

#### What does this implement/fix?
There were a few major bugs/issues in the 'sincnet.py' file which were creating difficulties in training the model with TensorFlow 2.4.1.  The issues are listed below: -
- Running the 'train.py' file raises a ValueError that "A tf.Variable created inside your tf.function has been garbage-collected." 
   which originated from the 'sinc' function defined in the 'sincnet.py' file. 
   A K.variable(K.ones(1)) is defined inside the function but it needs to be defined outside the function and then that variable 
   should be captured inside the function. So defined a variable outside the function as 
   > v = K.variable(K.ones(1))

   and then captured the variable inside the function as 

   > y = K.concatenate([y_left, v, y_right])  

- Running the 'train.py' file trains the model for 1 epoch then raises an error that '__init__ function has positional arguments so 
   you must override get_config'
   So added functions to override get_config method in both custom-defined Keras Layers - LayerNorm and SincConv1D

- Error while saving the trained model. While saving the model hdf5/h5 library throughs an error 'unable to create a link'. 
  This error usually occurs when multiple layers or their variables have the same names.  
  So each layer and variable should have unique names. Specified unique names to each layer in the 'model.py' file as well 
  as specified unique names to the 'window' and 't_right' attribute in the 'build' method of the SincConv1D class in the 
  'sincnet.py' file.
   